### PR TITLE
Clean up after automated tests

### DIFF
--- a/add-on-tool/tests/test_end_to_end.py
+++ b/add-on-tool/tests/test_end_to_end.py
@@ -71,28 +71,10 @@ def test_add_on(
     browser_context = page.context.browser.new_context(
         storage_state=api_request_context.storage_state()
     )
-    # workbench_page = browser_context.new_page()
-    # workbench_query_params = {
-    #     "trendItems": "Example>>Cooling Tower 1>>Area B>>Temperature",
-    #     "workbookName": f"{element_identifier} {datetime.datetime.now(pytz.utc).isoformat()}",
-    # }
-    # workbook_builder_url = (
-    #     f"{url}/workbook/builder/?{urlencode(workbench_query_params)}"
-    # )
-    # # capture the redirect to the built workbench
-    # workbench_page.goto(workbook_builder_url)
-    # workbench_page.wait_for_url("**/workbook/*/worksheet/*")
-    # expect(workbench_page.locator("id=header")).to_be_visible()
-
-    # workbook_id = spy.utils.get_workbook_id_from_url(test_workbook_url)
-    # worksheet_id = spy.utils.get_worksheet_id_from_url(test_workbook_url)
 
     # load the add-on with query parameters
     notebook_path = element_config["notebook_file_path"]
-    # add_on_query_params = {
-    #     "workbookId": workbook_id,
-    #     "worksheetId": worksheet_id,
-    # }
+
     add_on_url = f"""
     {url}/data-lab/{project_id}/addon/{notebook_path}?{urlencode(add_on_query_params)}
     """

--- a/add-on-tool/tests/test_end_to_end.py
+++ b/add-on-tool/tests/test_end_to_end.py
@@ -20,7 +20,7 @@ def add_on_query_params(
     )
     workbench_page = browser_context.new_page()
     workbench_query_params = {
-        "trendItems": "Example>>Cooling Tower 1>>Area B>>Temperature",
+        "trendItems": "Example>>Cooling Tower 2>>Area E>>Temperature",
         "workbookName": f"{element_identifier} {datetime.datetime.now(pytz.utc).isoformat()}",
     }
     workbook_builder_url = (

--- a/add-on-tool/tests/test_system.py
+++ b/add-on-tool/tests/test_system.py
@@ -162,7 +162,12 @@ def spc_accelerator_testing(request):
             "worksheet_id": worksheet_id,
         }
 
-    return test_workbooks
+    yield test_workbooks
+
+    # teardown logic - archive the workbooks
+    items_api = sdk.ItemsApi(spy.client)
+    for test in test_workbooks:
+        items_api.archive_item(id=test_workbooks[test]["workbook_id"])
 
 
 @pytest.mark.system


### PR DESCRIPTION
Previously, we would generate *checks notes* 10 different workbooks to perform our automated testing (runs every day).

This growing number of workbooks in a user folder slows down test execution to the point where it causes intermittent failures.

This PR adds in teardown steps to the system tests and e2e tests which will delete the generated workbooks after test execution. This should prevent workbooks from piling up and keep our tests happy!

**Exploratory Testing**
N/A - if tests pass we're all happy