### PR TITLE
Handle Discrete Inputs Gracefully

### DIFF
--- a/add-on-tool/spc_accelerator/backend.py
+++ b/add-on-tool/spc_accelerator/backend.py
@@ -479,14 +479,18 @@ def create_limit_signals(mean_stddev_push_df, signal_name):
 def western_electric_df(
     limits_push_df, mean_stddev_push_df, signal_name, interp_value, signals
 ):
+    input_signal = signals[signals["Name"] == signal_name]
+    # in order to handle discrete, we want to coerce to step using the max interp specified on the UI
+    is_discrete = input_signal["Interpolation Method"] == "None"
+    input_coercion_fragment = f".toStep({interp_value})" if is_discrete else ""
     western_electric_rules_df = pd.DataFrame(
         [
             {
                 "Name": f"{signal_name}: Western Electric Run Rule 1",
                 "Type": "Condition",
-                "Formula": f"$inputsignal.WesternElectricRunRules{ADD_ON_SUFFIX}_RunRule1($minus3sd, $plus3sd)",
+                "Formula": f"$inputsignal{input_coercion_fragment}.WesternElectricRunRules{ADD_ON_SUFFIX}_RunRule1($minus3sd, $plus3sd)",
                 "Formula Parameters": {
-                    "$inputsignal": signals[signals["Name"] == signal_name],
+                    "$inputsignal": input_signal,
                     "$minus3sd": limits_push_df[
                         limits_push_df["Name"] == f"{signal_name}: -3 Sigma"
                     ],
@@ -498,11 +502,11 @@ def western_electric_df(
             {
                 "Name": f"{signal_name}: Western Electric Run Rule 2",
                 "Type": "Condition",
-                "Formula": f"$inputsignal.WesternElectricRunRules{ADD_ON_SUFFIX}_RunRule2($minus2sd, $plus2sd, "
+                "Formula": f"$inputsignal{input_coercion_fragment}.WesternElectricRunRules{ADD_ON_SUFFIX}_RunRule2($minus2sd, $plus2sd, "
                 + interp_value
                 + ")",
                 "Formula Parameters": {
-                    "$inputsignal": signals[signals["Name"] == signal_name],
+                    "$inputsignal": input_signal,
                     "$minus2sd": limits_push_df[
                         limits_push_df["Name"] == f"{signal_name}: -2 Sigma"
                     ],
@@ -514,11 +518,11 @@ def western_electric_df(
             {
                 "Name": f"{signal_name}: Western Electric Run Rule 3",
                 "Type": "Condition",
-                "Formula": f"$inputsignal.WesternElectricRunRules{ADD_ON_SUFFIX}_RunRule3($minus1sd, $plus1sd, "
+                "Formula": f"$inputsignal{input_coercion_fragment}.WesternElectricRunRules{ADD_ON_SUFFIX}_RunRule3($minus1sd, $plus1sd, "
                 + interp_value
                 + ")",
                 "Formula Parameters": {
-                    "$inputsignal": signals[signals["Name"] == signal_name],
+                    "$inputsignal": input_signal,
                     "$minus1sd": limits_push_df[
                         limits_push_df["Name"] == f"{signal_name}: -1 Sigma"
                     ],
@@ -530,11 +534,11 @@ def western_electric_df(
             {
                 "Name": f"{signal_name}: Western Electric Run Rule 4",
                 "Type": "Condition",
-                "Formula": f"$inputsignal.WesternElectricRunRules{ADD_ON_SUFFIX}_RunRule4($mean, "
+                "Formula": f"$inputsignal{input_coercion_fragment}.WesternElectricRunRules{ADD_ON_SUFFIX}_RunRule4($mean, "
                 + interp_value
                 + ")",
                 "Formula Parameters": {
-                    "$inputsignal": signals[signals["Name"] == signal_name],
+                    "$inputsignal": input_signal,
                     "$mean": mean_stddev_push_df[
                         mean_stddev_push_df["Name"] == f"{signal_name}: Mean"
                     ],
@@ -546,14 +550,19 @@ def western_electric_df(
 
 
 def nelson_df(limits_push_df, mean_stddev_push_df, signal_name, interp_value, signals):
+    input_signal = signals[signals["Name"] == signal_name]
+    # in order to handle discrete, we want to coerce to step using the max interp specified on the UI
+    is_discrete = input_signal["Interpolation Method"] == "None"
+    input_coercion_fragment = f".toStep({interp_value})" if is_discrete else ""
+
     nelson_rules_df = pd.DataFrame(
         [
             {
                 "Name": f"{signal_name}: Nelson Run Rule 1",
                 "Type": "Condition",
-                "Formula": f"$inputsignal.NelsonRunRules{ADD_ON_SUFFIX}_RunRule1($minus3sd, $plus3sd)",
+                "Formula": f"$inputsignal{input_coercion_fragment}.NelsonRunRules{ADD_ON_SUFFIX}_RunRule1($minus3sd, $plus3sd)",
                 "Formula Parameters": {
-                    "$inputsignal": signals[signals["Name"] == signal_name],
+                    "$inputsignal": input_signal,
                     "$minus3sd": limits_push_df[
                         limits_push_df["Name"] == f"{signal_name}: -3 Sigma"
                     ],
@@ -565,11 +574,11 @@ def nelson_df(limits_push_df, mean_stddev_push_df, signal_name, interp_value, si
             {
                 "Name": f"{signal_name}: Nelson Run Rule 2",
                 "Type": "Condition",
-                "Formula": f"$inputsignal.NelsonRunRules{ADD_ON_SUFFIX}_RunRule2($mean, "
+                "Formula": f"$inputsignal{input_coercion_fragment}.NelsonRunRules{ADD_ON_SUFFIX}_RunRule2($mean, "
                 + interp_value
                 + ")",
                 "Formula Parameters": {
-                    "$inputsignal": signals[signals["Name"] == signal_name],
+                    "$inputsignal": input_signal,
                     "$mean": mean_stddev_push_df[
                         mean_stddev_push_df["Name"] == f"{signal_name}: Mean"
                     ],
@@ -578,31 +587,27 @@ def nelson_df(limits_push_df, mean_stddev_push_df, signal_name, interp_value, si
             {
                 "Name": f"{signal_name}: Nelson Run Rule 3",
                 "Type": "Condition",
-                "Formula": f"$inputsignal.NelsonRunRules{ADD_ON_SUFFIX}_RunRule3("
+                "Formula": f"$inputsignal{input_coercion_fragment}.NelsonRunRules{ADD_ON_SUFFIX}_RunRule3("
                 + interp_value
                 + ")",
-                "Formula Parameters": {
-                    "$inputsignal": signals[signals["Name"] == signal_name]
-                },
+                "Formula Parameters": {"$inputsignal": input_signal},
             },
             {
                 "Name": f"{signal_name}: Nelson Run Rule 4",
                 "Type": "Condition",
-                "Formula": f"$inputsignal.NelsonRunRules{ADD_ON_SUFFIX}_RunRule4("
+                "Formula": f"$inputsignal{input_coercion_fragment}.NelsonRunRules{ADD_ON_SUFFIX}_RunRule4("
                 + interp_value
                 + ")",
-                "Formula Parameters": {
-                    "$inputsignal": signals[signals["Name"] == signal_name]
-                },
+                "Formula Parameters": {"$inputsignal": input_signal},
             },
             {
                 "Name": f"{signal_name}: Nelson Run Rule 5",
                 "Type": "Condition",
-                "Formula": f"$inputsignal.NelsonRunRules{ADD_ON_SUFFIX}_RunRule5($minus2sd, $plus2sd, "
+                "Formula": f"$inputsignal{input_coercion_fragment}.NelsonRunRules{ADD_ON_SUFFIX}_RunRule5($minus2sd, $plus2sd, "
                 + interp_value
                 + ")",
                 "Formula Parameters": {
-                    "$inputsignal": signals[signals["Name"] == signal_name],
+                    "$inputsignal": input_signal,
                     "$minus2sd": limits_push_df[
                         limits_push_df["Name"] == f"{signal_name}: -2 Sigma"
                     ],
@@ -614,11 +619,11 @@ def nelson_df(limits_push_df, mean_stddev_push_df, signal_name, interp_value, si
             {
                 "Name": f"{signal_name}: Nelson Run Rule 6",
                 "Type": "Condition",
-                "Formula": f"$inputsignal.NelsonRunRules{ADD_ON_SUFFIX}_RunRule6($minus1sd, $plus1sd, "
+                "Formula": f"$inputsignal{input_coercion_fragment}.NelsonRunRules{ADD_ON_SUFFIX}_RunRule6($minus1sd, $plus1sd, "
                 + interp_value
                 + ")",
                 "Formula Parameters": {
-                    "$inputsignal": signals[signals["Name"] == signal_name],
+                    "$inputsignal": input_signal,
                     "$minus1sd": limits_push_df[
                         limits_push_df["Name"] == f"{signal_name}: -1 Sigma"
                     ],
@@ -630,11 +635,11 @@ def nelson_df(limits_push_df, mean_stddev_push_df, signal_name, interp_value, si
             {
                 "Name": f"{signal_name}: Nelson Run Rule 7",
                 "Type": "Condition",
-                "Formula": f"$inputsignal.NelsonRunRules{ADD_ON_SUFFIX}_RunRule7($minus1sd, $plus1sd, "
+                "Formula": f"$inputsignal{input_coercion_fragment}.NelsonRunRules{ADD_ON_SUFFIX}_RunRule7($minus1sd, $plus1sd, "
                 + interp_value
                 + ")",
                 "Formula Parameters": {
-                    "$inputsignal": signals[signals["Name"] == signal_name],
+                    "$inputsignal": input_signal,
                     "$minus1sd": limits_push_df[
                         limits_push_df["Name"] == f"{signal_name}: -1 Sigma"
                     ],
@@ -646,11 +651,11 @@ def nelson_df(limits_push_df, mean_stddev_push_df, signal_name, interp_value, si
             {
                 "Name": f"{signal_name}: Nelson Run Rule 8",
                 "Type": "Condition",
-                "Formula": f"$inputsignal.NelsonRunRules{ADD_ON_SUFFIX}_RunRule8($minus1sd, $plus1sd, "
+                "Formula": f"$inputsignal{input_coercion_fragment}.NelsonRunRules{ADD_ON_SUFFIX}_RunRule8($minus1sd, $plus1sd, "
                 + interp_value
                 + ")",
                 "Formula Parameters": {
-                    "$inputsignal": signals[signals["Name"] == signal_name],
+                    "$inputsignal": input_signal,
                     "$minus1sd": limits_push_df[
                         limits_push_df["Name"] == f"{signal_name}: -1 Sigma"
                     ],

--- a/add-on-tool/spc_accelerator/backend.py
+++ b/add-on-tool/spc_accelerator/backend.py
@@ -481,7 +481,7 @@ def western_electric_df(
 ):
     input_signal = signals[signals["Name"] == signal_name]
     # in order to handle discrete, we want to coerce to step using the max interp specified on the UI
-    is_discrete = input_signal["Interpolation Method"] == "None"
+    is_discrete = (input_signal["Interpolation Method"] == "None").any()
     input_coercion_fragment = f".toStep({interp_value})" if is_discrete else ""
     western_electric_rules_df = pd.DataFrame(
         [
@@ -552,7 +552,7 @@ def western_electric_df(
 def nelson_df(limits_push_df, mean_stddev_push_df, signal_name, interp_value, signals):
     input_signal = signals[signals["Name"] == signal_name]
     # in order to handle discrete, we want to coerce to step using the max interp specified on the UI
-    is_discrete = input_signal["Interpolation Method"] == "None"
+    is_discrete = (input_signal["Interpolation Method"] == "None").any()
     input_coercion_fragment = f".toStep({interp_value})" if is_discrete else ""
 
     nelson_rules_df = pd.DataFrame(

--- a/add-on-tool/spc_accelerator/utils.py
+++ b/add-on-tool/spc_accelerator/utils.py
@@ -12,6 +12,9 @@ def pull_worksheet_data(URL, workbook_id, worksheet_id):
         worksheet_items = spy.search(URL, quiet=True)
         signals = worksheet_items[worksheet_items["Type"].str.contains("Signal")]
         signal_list = signals["Name"].to_list()
+        signals_with_properties = spy.search(
+            signals, include_properties=["Interpolation Method"]
+        )
         conditions = worksheet_items[worksheet_items["Type"].str.contains("Condition")]
         condition_list = conditions["Name"].to_list()
         workstep_id = (
@@ -31,7 +34,14 @@ def pull_worksheet_data(URL, workbook_id, worksheet_id):
         start_time = datetime.fromtimestamp(start / 1000).astimezone()
         end_time = datetime.fromtimestamp(end / 1000).astimezone()
 
-        return signal_list, condition_list, start_time, end_time, signals, conditions
+        return (
+            signal_list,
+            condition_list,
+            start_time,
+            end_time,
+            signals_with_properties,
+            conditions,
+        )
     except:
         worksheet_items = pd.DataFrame()
         signals = pd.DataFrame()

--- a/add-on-tool/spc_accelerator/utils.py
+++ b/add-on-tool/spc_accelerator/utils.py
@@ -13,7 +13,7 @@ def pull_worksheet_data(URL, workbook_id, worksheet_id):
         signals = worksheet_items[worksheet_items["Type"].str.contains("Signal")]
         signal_list = signals["Name"].to_list()
         signals_with_properties = spy.search(
-            signals, include_properties=["Interpolation Method"]
+            signals, include_properties=["Interpolation Method"], quiet=True
         )
         conditions = worksheet_items[worksheet_items["Type"].str.contains("Condition")]
         condition_list = conditions["Name"].to_list()

--- a/addon.jsonnet
+++ b/addon.jsonnet
@@ -15,7 +15,7 @@ function(suffix='')
 
       https://github.com/seeq12/seeq-add-on-spc-accelerator/issues
     |||,
-    version: '1.0.2',
+    version: '1.1.0',
     license: 'Apache 2.0',
     icon: 'fa-bullseye',
     maintainer: 'Seeq Corporation',  // set to Seeq Corporation for AE developed add-ons
@@ -61,10 +61,10 @@ function(suffix='')
               properties: {
                 kernel_name: {
                   type: 'string',
-                  default: 'python38'
-                }
-              }
-            }
+                  default: 'python38',
+                },
+              },
+            },
           },
           required: ['display', 'advanced_project_configuration'] + if suffix != '' then ['project'] else [],
         },

--- a/addon.jsonnet
+++ b/addon.jsonnet
@@ -16,7 +16,6 @@ function(suffix='')
       https://github.com/seeq12/seeq-add-on-spc-accelerator/issues
     |||,
     version: '1.1.0',
-    version: '1.0.3',
     license: 'Apache 2.0',
     icon: 'fa-bullseye',
     maintainer: 'Seeq Corporation',  // set to Seeq Corporation for AE developed add-ons
@@ -61,13 +60,13 @@ function(suffix='')
               properties: {
                 kernel_name: {
                   type: 'string',
-                  default: 'python311'
-                }
+                  default: 'python311',
+                },
               },
               required: [
-                  'kernel_name'
-                ]
-            }
+                'kernel_name',
+              ],
+            },
           },
           required: ['display', 'advanced_project_configuration'] + if suffix != '' then ['project'] else [],
         },

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -20,3 +20,7 @@ Release Notes
    * - 1.0.2
      - Add-on now skips full workbook inventory pushes and pulls
      - 
+
+   * - 1.1.0
+     - Discrete signals are now supported
+     - 


### PR DESCRIPTION
Previously, when a discrete signal was selected as as input, the add-on would error out and provide no indication to the user if Run Rules were selected. This was due to the Nelson and Western Electric Run Rule UDFs expecting a continuous signal. Now, we apply the max interp specified in the UI when generating the output formulas.